### PR TITLE
Integrate handover logic in SmartFA analysis

### DIFF
--- a/PESystem/Areas/SmartFA/Views/Analysis/Index.cshtml
+++ b/PESystem/Areas/SmartFA/Views/Analysis/Index.cshtml
@@ -57,8 +57,8 @@
             {
                 <button class="btn btn-outline-info btn-check-list">CHECK LIST</button>
             }
-            <button class="btn btn-outline-danger">Giao</button>
-            <button class="btn btn-outline-success">Nhận</button>
+            <button id="btn-handover" class="btn btn-outline-danger">Giao</button>
+            <button id="btn-receive" class="btn btn-outline-success">Nhận</button>
 
         </div>
 </div>
@@ -411,6 +411,24 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Modal nhập vị trí khi nhận bản -->
+    <div class="modal fade" id="locationModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nhập vị trí</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="text" id="locationInput" class="form-control" placeholder="Vị trí (Location)">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
+                    <button type="button" id="confirmLocation" class="btn btn-ne">Xác nhận</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add handover/receive buttons and location modal in Analysis view
- expose existing serial set and table removal helper
- add receiving/handover API calls
- implement `HandoverManager` in analysis.js and initialize it

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864b145a16c832b937415992eb0d0ff