### PR TITLE
Add location charts and aging info

### DIFF
--- a/API_WEB/Controllers/SmartFA/SearchFAController.cs
+++ b/API_WEB/Controllers/SmartFA/SearchFAController.cs
@@ -51,6 +51,7 @@ namespace API_WEB.Controllers.SmartFA
                           && (string.IsNullOrEmpty(request.TestCode) || task.TEST_CODE == request.TestCode)
                           && (string.IsNullOrEmpty(request.Status) || task.DATA11 == request.Status)
                           && (string.IsNullOrEmpty(request.HandoverStatus) || task.DATA13 == request.HandoverStatus)
+                          && (string.IsNullOrEmpty(request.Location) || task.DATA18 == request.Location)
                     select new
                     {
                         task.SERIAL_NUMBER,

--- a/API_WEB/Models/SmartFA/SearchRequestNe.cs
+++ b/API_WEB/Models/SmartFA/SearchRequestNe.cs
@@ -8,6 +8,6 @@
         public string? Status { get; set; } // DATA11
         public string? Data1 { get; set; }
         public string? HandoverStatus { get; set; }
-        //public string? Location { get; set; }
+        public string? Location { get; set; }
     }
 }

--- a/PESystem/Areas/SmartFA/Views/Analysis/Index.cshtml
+++ b/PESystem/Areas/SmartFA/Views/Analysis/Index.cshtml
@@ -93,6 +93,13 @@
         </table>
     </div>
 
+    <div class="chart-container" style="width: 80%; margin: auto; padding: 20px;">
+        <canvas id="locationChart" style="max-height: 400px;"></canvas>
+    </div>
+    <div class="chart-container" style="width: 80%; margin: auto; padding: 20px;">
+        <canvas id="handoverStatusChart" style="max-height: 400px;"></canvas>
+    </div>
+
     <!-- Modal Thêm Guide -->
     <div class="modal fade" id="guideModal" tabindex="-1">
         <div class="modal-dialog modal-lg">
@@ -438,6 +445,8 @@
 
 @section Scripts {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="~/assets/vendor/chart.js/chart.umd.js"></script>
+    <script src="~/assets/vendor/chart.js/chartjs-plugin-datalabels.js"></script>
     <script src="~/assets/areas/smartfa/js/analysis.js?v=@DateTime.Now.Ticks"></script>
     <style>
         body {

--- a/PESystem/Areas/SmartFA/Views/Analysis/Index.cshtml
+++ b/PESystem/Areas/SmartFA/Views/Analysis/Index.cshtml
@@ -94,10 +94,36 @@
     </div>
 
     <div class="chart-container" style="width: 80%; margin: auto; padding: 20px;">
-        <canvas id="locationChart" style="max-height: 400px;"></canvas>
+        <div id="locationChart" style="max-height: 400px;"></div>
     </div>
     <div class="chart-container" style="width: 80%; margin: auto; padding: 20px;">
         <canvas id="handoverStatusChart" style="max-height: 400px;"></canvas>
+    </div>
+
+    <div class="modal fade" id="locationDetailModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Chi tiết vị trí <span id="detailLocationName"></span></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <table class="table table-bordered" id="locationDetailTable">
+                        <thead>
+                            <tr>
+                                <th>SERIAL_NUMBER</th>
+                                <th>TEST_CODE</th>
+                                <th>ERROR_DESC</th>
+                                <th>MO_NUMBER</th>
+                                <th>MODEL_NAME</th>
+                                <th>AGING (days)</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Modal Thêm Guide -->
@@ -445,6 +471,7 @@
 
 @section Scripts {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="~/assets/vendor/apexcharts/apexcharts.min.js"></script>
     <script src="~/assets/vendor/chart.js/chart.umd.js"></script>
     <script src="~/assets/vendor/chart.js/chartjs-plugin-datalabels.js"></script>
     <script src="~/assets/areas/smartfa/js/analysis.js?v=@DateTime.Now.Ticks"></script>


### PR DESCRIPTION
## Summary
- add API to compute location counts with aging
- support location filtering in search requests
- show SN counts by location and handover status charts in analysis view
- fix stray characters in analysis script

## Testing
- `dotnet build PESystem.sln -c Release` *(fails: command not found)*
- `npm test` *(fails: missing script)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6864d99f8f5c832b88c7616dabbb44b7